### PR TITLE
Fix LDAPObfuscator object has no attribute obfuscate

### DIFF
--- a/utilities/ui_dialogs.py
+++ b/utilities/ui_dialogs.py
@@ -718,7 +718,7 @@ class ObfuscationDialog(QDialog):
             
         try:
             # Obfuscate
-            obfuscated = self.obfuscator.obfuscate(input_query, techniques)
+            obfuscated = self.obfuscator.obfuscate_filter(input_query, techniques)
             
             # Display result
             self.output_text.setPlainText(obfuscated)


### PR DESCRIPTION
There is a typo in line 721 of ui_dialogs.py that causes LDAP query obfuscation to not work properly.
<img width="2400" height="1644" alt="image" src="https://github.com/user-attachments/assets/e81bb719-9dc2-4941-8637-d6d6ae8bc073" />

```
self.obfuscator.obfuscate(input_query, techniques) -> self.obfuscator.obfuscate_filter(input_query, techniques)
```
<img width="2406" height="1648" alt="image" src="https://github.com/user-attachments/assets/5ea4f507-7c3f-4c5b-bcdb-bba3463db02c" />
